### PR TITLE
Restrict wheels download to blender python version

### DIFF
--- a/peeler/command/wheels.py
+++ b/peeler/command/wheels.py
@@ -5,16 +5,16 @@
 from pathlib import Path
 from typing import List
 
-from tomlkit.toml_file import TOMLFile
 import typer
 from click import format_filename
 from click.exceptions import ClickException
+from tomlkit.toml_file import TOMLFile
 
+from peeler.pyproject.utils import Pyproject
+from peeler.utils import find_pyproject_file, restore_file
 from peeler.uv_utils import check_uv_version
-
-from ..utils import find_pyproject_file
-from ..wheels.download import download_wheels
-from ..wheels.lock import get_wheels_url
+from peeler.wheels.download import download_wheels
+from peeler.wheels.lock import get_wheels_url
 
 PYPROJECT_FILENAME = "pyproject.toml"
 
@@ -124,6 +124,24 @@ def write_wheels_path(blender_manifest_path: Path, wheels_paths: List[Path]) -> 
     file.write(doc)
 
 
+def _update_pyproject_to_supported(pyproject_file: Path) -> None:
+    """Update a pyproject file to match feature supported by Blender.
+
+    :param pyproject_file: the pyproject filepath
+    """
+
+    file = TOMLFile(pyproject_file)
+
+    pyproject = Pyproject(file.read())
+
+    pyproject.project_table.update(
+        {
+            "requires-python": "==3.11.*"
+        }
+    )
+
+    file.write(pyproject._document)
+
 def wheels_command(
     pyproject_file: Path, blender_manifest_file: Path, wheels_directory: Path | None
 ) -> None:
@@ -137,11 +155,16 @@ def wheels_command(
     check_uv_version()
 
     pyproject_file = find_pyproject_file(pyproject_file, allow_non_default_name=False)
+
     wheels_directory = _resolve_wheels_dir(
         wheels_directory, blender_manifest_file, allow_non_default_name=True
     )
 
-    urls = get_wheels_url(pyproject_file)
+    # temporary modify pyproject file
+    # to download only supported wheels by blender
+    with restore_file(pyproject_file):
+        _update_pyproject_to_supported(pyproject_file)
+        urls = get_wheels_url(pyproject_file)
 
     wheels_paths = download_wheels(wheels_directory, urls)
 

--- a/peeler/pyproject/__init__.py
+++ b/peeler/pyproject/__init__.py
@@ -1,0 +1,12 @@
+# # SPDX-FileCopyrightText: 2025 Maxime Letellier <maxime.eliot.letellier@gmail.com>
+#
+# # SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Module for parsing, validating and updating a pyproject.toml file."""
+
+from dep_logic.specifiers import RangeSpecifier
+from packaging.version import Version
+
+_BLENDER_SUPPORTED_PYTHON_VERSION = RangeSpecifier(
+    Version("3.11"), Version("3.12"), include_min=True, include_max=False
+)

--- a/peeler/pyproject/update.py
+++ b/peeler/pyproject/update.py
@@ -1,0 +1,33 @@
+# # SPDX-FileCopyrightText: 2025 Maxime Letellier <maxime.eliot.letellier@gmail.com>
+#
+# # SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+from tomlkit.toml_file import TOMLFile
+
+from peeler.pyproject.utils import Pyproject
+
+_BLENDER_SUPPORTED_PYTHON_VERSIONS = SpecifierSet(">=3.11,<3.12")
+
+
+def update_requires_python(pyproject: Pyproject) -> Pyproject:
+    """Update a pyproject file to restrict project supported python version to the versions supported by Blender.
+
+    The specifier set will not be resolved, and can lead to contradictions.
+
+    :param pyproject_file: the pyproject
+
+    :return: the parsed pyproject
+    """
+
+    requires_python = SpecifierSet(
+        str(pyproject.project_table.get("requires-python", ""))
+    )
+
+    requires_python &= _BLENDER_SUPPORTED_PYTHON_VERSIONS
+
+    pyproject.project_table.update({"requires-python": str(requires_python)})
+
+    return pyproject

--- a/peeler/pyproject/update.py
+++ b/peeler/pyproject/update.py
@@ -2,17 +2,14 @@
 #
 # # SPDX-License-Identifier: GPL-3.0-or-later
 
-from pathlib import Path
-
 from packaging.specifiers import SpecifierSet
-from tomlkit.toml_file import TOMLFile
 
-from peeler.pyproject.utils import Pyproject
+from peeler.pyproject.parser import PyprojectParser
 
 _BLENDER_SUPPORTED_PYTHON_VERSIONS = SpecifierSet(">=3.11,<3.12")
 
 
-def update_requires_python(pyproject: Pyproject) -> Pyproject:
+def update_requires_python(pyproject: PyprojectParser) -> PyprojectParser:
     """Update a pyproject file to restrict project supported python version to the versions supported by Blender.
 
     The specifier set will not be resolved, and can lead to contradictions.

--- a/peeler/pyproject/update.py
+++ b/peeler/pyproject/update.py
@@ -2,11 +2,11 @@
 #
 # # SPDX-License-Identifier: GPL-3.0-or-later
 
-from packaging.specifiers import SpecifierSet
 
 from peeler.pyproject.parser import PyprojectParser
+from dep_logic.specifiers import parse_version_specifier
 
-_BLENDER_SUPPORTED_PYTHON_VERSIONS = SpecifierSet(">=3.11,<3.12")
+from peeler.pyproject import _BLENDER_SUPPORTED_PYTHON_VERSION
 
 
 def update_requires_python(pyproject: PyprojectParser) -> PyprojectParser:
@@ -19,11 +19,11 @@ def update_requires_python(pyproject: PyprojectParser) -> PyprojectParser:
     :return: the parsed pyproject
     """
 
-    requires_python = SpecifierSet(
-        str(pyproject.project_table.get("requires-python", ""))
+    requires_python = parse_version_specifier(
+        pyproject.project_table.get("requires-python", "")
     )
 
-    requires_python &= _BLENDER_SUPPORTED_PYTHON_VERSIONS
+    requires_python &= _BLENDER_SUPPORTED_PYTHON_VERSION
 
     pyproject.project_table.update({"requires-python": str(requires_python)})
 

--- a/peeler/pyproject/validator.py
+++ b/peeler/pyproject/validator.py
@@ -13,12 +13,10 @@ from tomlkit import TOMLDocument
 from validate_pyproject.api import Validator as _Validator
 from validate_pyproject.plugins import PluginWrapper
 
+from peeler.pyproject import _BLENDER_SUPPORTED_PYTHON_VERSION
+
 from ..schema import peeler_json_schema
 from .parser import PyprojectParser
-
-_BLENDER_SUPPORTED_PYTHON_VERSION = RangeSpecifier(
-    Version("3.11"), Version("3.12"), include_min=True, include_max=False
-)
 
 
 def _peeler_plugin(_: str) -> Dict[str, Any]:

--- a/tests/peeler/pyproject/conftest.py
+++ b/tests/peeler/pyproject/conftest.py
@@ -11,6 +11,23 @@ from peeler.pyproject.manifest_adapter import ManifestAdapter
 from peeler.pyproject.validator import PyprojectValidator
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
+PYPROJECT_MINIMAL = TEST_DATA_DIR / "pyproject_no_peeler_table.toml"
+
+
+@fixture
+def pyproject_requires_python(request: FixtureRequest) -> PyprojectValidator:
+    key = "requires-python"
+
+    pyproject = PyprojectValidator(TOMLFile(PYPROJECT_MINIMAL).read())
+
+    requires_python: str | None = request.param
+
+    if requires_python is not None:
+        pyproject.project_table.update({key: str(request.param)})
+    elif key in pyproject.project_table:
+        del pyproject.project_table[key]
+
+    return pyproject
 
 
 @fixture

--- a/tests/peeler/pyproject/conftest.py
+++ b/tests/peeler/pyproject/conftest.py
@@ -8,6 +8,7 @@ from tomlkit.items import Table
 from tomlkit.toml_file import TOMLFile
 
 from peeler.pyproject.manifest_adapter import ManifestAdapter
+from peeler.pyproject.parser import PyprojectParser
 from peeler.pyproject.validator import PyprojectValidator
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
@@ -15,10 +16,10 @@ PYPROJECT_MINIMAL = TEST_DATA_DIR / "pyproject_no_peeler_table.toml"
 
 
 @fixture
-def pyproject_requires_python(request: FixtureRequest) -> PyprojectValidator:
+def pyproject_requires_python(request: FixtureRequest) -> PyprojectParser:
     key = "requires-python"
 
-    pyproject = PyprojectValidator(TOMLFile(PYPROJECT_MINIMAL).read())
+    pyproject = PyprojectParser(TOMLFile(PYPROJECT_MINIMAL).read())
 
     requires_python: str | None = request.param
 

--- a/tests/peeler/pyproject/test_update.py
+++ b/tests/peeler/pyproject/test_update.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+from pytest import mark
+
+from peeler.pyproject.update import update_requires_python
+from peeler.pyproject.parser import PyprojectParser
+
+
+@mark.parametrize(
+    "pyproject_requires_python", (None, ">=3.9.0,<3.14", "==3.11.*"), indirect=True
+)
+def test_update_requires_python(pyproject_requires_python: PyprojectParser) -> None:
+    pyproject = update_requires_python(pyproject_requires_python)
+    requires_python = SpecifierSet(pyproject.project_table["requires-python"])
+
+    assert requires_python  # no canonical ways to test version range intersection
+
+
+@mark.parametrize(
+    "pyproject_requires_python",
+    (">=3.11.10,<3.12", ">=3.11.7,<=3.13", ">3.11.5"),
+    indirect=True,
+)
+def test_update_requires_python_restritive(
+    pyproject_requires_python: PyprojectParser,
+) -> None:
+    pyproject = update_requires_python(pyproject_requires_python)
+    requires_python = SpecifierSet(pyproject.project_table["requires-python"])
+
+    assert Version("3.11.5") not in requires_python


### PR DESCRIPTION
Blender 4.2+ only support python 3.11.*.

This PR ensure that the `requires-python` field contains only 3.11 in `pyproject.toml` when resolving lock file to avoid downloading wheels python != 3.11

Close #6 