### PR TITLE
Validate python version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ keywords = ["blender", "add-on"]
 version = "0.0.1"
 
 dependencies = [
+    "dep-logic>=0.4.11",
     "jsonschema>=4.23.0",
+    "packaging>=24.2",
     "pyproject-metadata>=0.9.0",
     "rich>=13.9.4",
     "tomlkit>=0.13.2",

--- a/tests/peeler/pyproject/conftest.py
+++ b/tests/peeler/pyproject/conftest.py
@@ -1,12 +1,14 @@
-from typing import Any, Dict
-from pytest import fixture, FixtureRequest
 from pathlib import Path
+from typing import Any, Dict
+
 import tomlkit
+from pytest import FixtureRequest, fixture
 from tomlkit import TOMLDocument
+from tomlkit.items import Table
+from tomlkit.toml_file import TOMLFile
 
-from peeler.pyproject.validator import Validator
 from peeler.pyproject.parse import Parser
-
+from peeler.pyproject.validator import Validator
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 
@@ -39,3 +41,16 @@ def parser(
         return Parser(
             tomlkit.load(file), blender_manifest_schema, peeler_manifest_schema
         )
+
+@fixture(scope="function")
+def validator_requires_python(request: FixtureRequest) -> Validator:
+    path: Path = TEST_DATA_DIR / "pyproject_minimal.toml"
+
+    document = TOMLFile(path).read()
+
+    project_table: Table = document.get("project")
+
+    project_table.update({"requires-python": request.param})
+
+    return Validator(document, path)
+

--- a/tests/peeler/pyproject/test_validator.py
+++ b/tests/peeler/pyproject/test_validator.py
@@ -36,3 +36,28 @@ def test_validator(validator: Validator) -> None:
 def test_validator_invalid(validator: Validator, match: str) -> None:
     with pytest.raises(ValidationError, match=match):
         validator.validate()
+
+
+@pytest.mark.parametrize(
+    "validator_requires_python",
+    [
+        ">=3.6",
+        "==3.11",
+    ],
+    indirect=True,
+)
+def test_validator_requires_python(validator_requires_python: Validator) -> None:
+
+    validator_requires_python.validate()
+
+@pytest.mark.parametrize(
+    "validator_requires_python",
+    [
+        "<=3.5",
+        "<3.11",
+    ],
+    indirect=True,
+)
+def test_validator_requires_python_invalid(validator_requires_python: Validator) -> None:
+    with pytest.raises(ValidationError):
+        validator_requires_python.validate()

--- a/tests/peeler/pyproject/test_validator.py
+++ b/tests/peeler/pyproject/test_validator.py
@@ -39,25 +39,44 @@ def test_validator_invalid(validator: Validator, match: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "validator_requires_python",
+    "validator",
     [
-        ">=3.6",
-        "==3.11",
+        "pyproject_minimal.toml",
     ],
     indirect=True,
 )
-def test_validator_requires_python(validator_requires_python: Validator) -> None:
+def test_validator_requires_python_empty(validator: Validator) -> None:
+    try:
+        validator.validate()
+    except ValidationError as e:
+        pytest.fail(f"Should not raise a ValidationError: {e.message}")
 
-    validator_requires_python.validate()
+
+@pytest.mark.parametrize(
+    "validator_requires_python",
+    [">=3.6", "==3.11.*", ">=3.11.9,<3.13", "~=3.11.2", "==3.11.7"],
+    indirect=True,
+)
+def test_validator_requires_python(validator_requires_python: Validator) -> None:
+    try:
+        validator_requires_python.validate()
+    except ValidationError as e:
+        pytest.fail(f"Should not raise a ValidationError: {e.message}")
+
 
 @pytest.mark.parametrize(
     "validator_requires_python",
     [
         "<=3.5",
         "<3.11",
+        ">=3.12.0,<3.13",
+        "~=3.12.0",
+        "~=3.7.0",
     ],
     indirect=True,
 )
-def test_validator_requires_python_invalid(validator_requires_python: Validator) -> None:
-    with pytest.raises(ValidationError):
+def test_validator_requires_python_invalid(
+    validator_requires_python: Validator,
+) -> None:
+    with pytest.raises(ValidationError, match="requires-python"):
         validator_requires_python.validate()

--- a/uv.lock
+++ b/uv.lock
@@ -86,6 +86,18 @@ toml = [
 ]
 
 [[package]]
+name = "dep-logic"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/d8/11db71e3b8961152a777258cf627f9fe9bacce7ec2f2e07d2e8c6ad0cd90/dep_logic-0.4.11.tar.gz", hash = "sha256:6084c81ce683943a60394ca0f8531ff803dfd955b5d7f52fb0571b53b930a182", size = 35450 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/30/6504e03132820608b2a92957f82ced57df81051f342cc6f1c32e1e5c5681/dep_logic-0.4.11-py3-none-any.whl", hash = "sha256:44cf69b3e0e369315e7d4cafa4a5050aa70666753831bf0c27b7f3eadbcf70ce", size = 34493 },
+]
+
+[[package]]
 name = "fastjsonschema"
 version = "2.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -165,7 +177,9 @@ name = "peeler"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "dep-logic" },
     { name = "jsonschema" },
+    { name = "packaging" },
     { name = "pyproject-metadata" },
     { name = "rich" },
     { name = "tomlkit" },
@@ -188,7 +202,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dep-logic", specifier = ">=0.4.11" },
     { name = "jsonschema", specifier = ">=4.23.0" },
+    { name = "packaging", specifier = ">=24.2" },
     { name = "pyproject-metadata", specifier = ">=0.9.0" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "tomlkit", specifier = ">=0.13.2" },


### PR DESCRIPTION
Ensure that the field `project.requires-python` in `pyproject.toml` contains a python version supported by Blender 4.2+ (currently 3.11)

Close #8 