### PR TITLE
Retrieve max uv version from .max-uv-version file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ Update lock file generation, allow uv versions from 0.5.17 to 0.6.1 [#22](https:
 ## [0.2.3]
 
 Update README.md
+Improve error messages when uv version is not currently supported [#26](https://github.com/Maxioum/Peeler/pull/26)

--- a/peeler/__init__.py
+++ b/peeler/__init__.py
@@ -9,4 +9,10 @@ A tool to create or update a blender_manifest.toml from a pyproject.toml
 
 from pathlib import Path
 
+from packaging.version import Version
+
 DATA_DIR = Path(__file__).parent / "data"
+
+MIN_UV_VERSION = Version("0.5.17")
+
+MAX_UV_VERSION = Version((Path(__file__).parent.parent / ".max-uv-version").read_text())

--- a/peeler/uv_utils.py
+++ b/peeler/uv_utils.py
@@ -66,27 +66,48 @@ def get_uv_version() -> Version | None:
 
 
 def check_uv_version() -> None:
-    """Check the current uv version is between 0.5.17 and 0.6.1.
+    """Check the current uv version is between 0.5.17 and current supported max uv version.
+
+    See .max-uv-version or pyproject.toml files.
 
     :raises ClickException: if uv version cannot be determined or is lower than the minimum version.
     """
 
     uv_version = get_uv_bin_version(Path(find_uv_bin()))
 
-    if not uv_version:
-        import peeler
+    try:
+        import uv
+    except (ModuleNotFoundError, FileNotFoundError):
+        from_pip = False
+    else:
+        from_pip = True
 
-        raise ClickException(
-            f"""Error when checking uv version
-To use {peeler.__name__} wheels feature uv must be between {MIN_UV_VERSION} and {MAX_UV_VERSION}
-Run `uv self update` to update uv"""
-        )
+    import peeler
+
+    body = f"To use {peeler.__name__} wheels feature uv version must be between {MIN_UV_VERSION} and {MAX_UV_VERSION}"
+
+    if from_pip:
+        update_uv = """Install peeler with a supported uv version:
+
+pip install peeler[uv]"""
+    else:
+        update_uv = f"""Use peeler with a supported uv version without changing your current uv installation:
+
+uvx peeler[uv] [OPTIONS] COMMAND [ARGS]"""
+
+    if not uv_version:
+        header = "Error when checking uv version. Make sur to have installed, visit: https://docs.astral.sh/uv/getting-started/installation/"
+        raise ClickException(f"""{header}
+
+{body}
+
+{update_uv}""")
 
     if uv_version > MAX_UV_VERSION or uv_version < MIN_UV_VERSION:
         import peeler
 
-        raise ClickException(
-            f"""uv version is {uv_version}
-To use {peeler.__name__} wheels feature uv must be between {MIN_UV_VERSION} and {MAX_UV_VERSION}
-Run `uv self update` to update uv"""
-        )
+        header = f"uv version is {uv_version}"
+
+        raise ClickException(f"""{header}
+{body}
+{update_uv}""")

--- a/peeler/uv_utils.py
+++ b/peeler/uv_utils.py
@@ -11,9 +11,9 @@ from subprocess import run
 from click import ClickException
 from packaging.version import Version
 
+from peeler import MAX_UV_VERSION, MIN_UV_VERSION
+
 version_regex = r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
-_MIN_UV_VERSION = Version("0.5.17")
-_MAX_UV_VERSION = Version("0.6.1")
 
 
 def get_uv_bin_version(uv_bin: PathLike) -> Version | None:
@@ -78,15 +78,15 @@ def check_uv_version() -> None:
 
         raise ClickException(
             f"""Error when checking uv version
-To use {peeler.__name__} wheels feature uv must be between {_MIN_UV_VERSION} and {_MAX_UV_VERSION}
+To use {peeler.__name__} wheels feature uv must be between {MIN_UV_VERSION} and {MAX_UV_VERSION}
 Run `uv self update` to update uv"""
         )
 
-    if uv_version > _MAX_UV_VERSION or uv_version < _MIN_UV_VERSION:
+    if uv_version > MAX_UV_VERSION or uv_version < MIN_UV_VERSION:
         import peeler
 
         raise ClickException(
             f"""uv version is {uv_version}
-To use {peeler.__name__} wheels feature uv must be between {_MIN_UV_VERSION} and {_MAX_UV_VERSION}
+To use {peeler.__name__} wheels feature uv must be between {MIN_UV_VERSION} and {MAX_UV_VERSION}
 Run `uv self update` to update uv"""
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
 path = "version.txt"
 
 [tool.hatch.build]
-include = ["peeler"]
+include = ["peeler", ".max-uv-version"]
 exclude = ["tests"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
- Retrieve max supported uv version from the .max-uv-version file used by workfows
- check_uv_version use this file
- Improve check_uv_version error messages