### PR TITLE
Implement a new UrlsFilter to exclude 'FreeThreaded' wheels

### DIFF
--- a/peeler/cli.py
+++ b/peeler/cli.py
@@ -1,4 +1,4 @@
-# # SPDX-FileCopyrightText: 2025 Maxime Letellier <maxime.eliot.letellier@gmail.com>
+# # SPDX-FileCopyrightText: 2025-2026 Maxime Letellier <maxime.eliot.letellier@gmail.com>
 #
 # # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,7 +10,7 @@ from typer import Argument, Option, Typer
 app = Typer()
 
 
-@app.command(help=f"Display the current installed version.", hidden=True)
+@app.command(help="Display the current installed version.", hidden=True)
 def version() -> None:
     """Call the version command."""
 
@@ -20,7 +20,7 @@ def version() -> None:
 
 
 @app.command(
-    help=f"Create or update a blender_manifest.toml file from a pyproject.toml file.",
+    help="Create or update a blender_manifest.toml file from a pyproject.toml file.",
 )
 def manifest(
     pyproject: Annotated[Path, Argument()],
@@ -87,6 +87,13 @@ def wheels(
             show_default=False,
         ),
     ] = None,
+    include_free_threaded_wheels: Annotated[
+        bool,
+        Option(
+            help="Whether to include free threaded wheels. See https://docs.blender.org/api/current/info_gotchas_threading.html .",
+            show_default=True,
+        ),
+    ] = False,
 ) -> None:
     """Download wheels and write their paths to the Blender manifest."""
 
@@ -99,6 +106,7 @@ def wheels(
         exclude_package,
         exclude_dependency,
         exclude_dependency_groups,
+        include_free_threaded_wheels,
     )
 
 

--- a/peeler/command/wheels.py
+++ b/peeler/command/wheels.py
@@ -165,12 +165,14 @@ def wheels_command(
     excluded_packages: Optional[List[str]] = None,
     excluded_dependency: Optional[List[str]] = None,
     excluded_dependency_group: Optional[List[str]] = None,
+    include_free_threaded_wheels: bool = False,
 ) -> None:
     """Download wheel from pyproject dependency and write their paths to the blender manifest.
 
     :param file: The pyproject / uv.lock / pylock file or directory.
-    :param blender_manifest_file: the blender manifest file
+    :param blender_manifest_file: the blender manifest file.
     :param wheels_directory: the directory to download wheels into.
+    :param include_free_threaded_wheels: whether to include free threaded wheels
     """
 
     blender_manifest_file = _resolve_blender_manifest_file(
@@ -195,6 +197,7 @@ def wheels_command(
         urls,
         excluded_packages=excluded_packages,
         supported_platforms=supported_platform,
+        include_free_threaded_wheels=include_free_threaded_wheels,
     )
 
     write_wheels_path(blender_manifest_file, wheels_paths)

--- a/peeler/wheels/download.py
+++ b/peeler/wheels/download.py
@@ -263,6 +263,43 @@ class PlatformIsNotExcluded(UrlsFilter):
         return urls
 
 
+class IsNotFreeThreaded(UrlsFilter):
+    """Filter out urls for free threaded wheels.
+
+    Free threaded wheels are not compatible with blender and can cause issues when installed.
+    See https://docs.blender.org/api/current/info_gotchas_threading.html .
+
+    :param package_name: Optional name of the package, used in warning messages.
+    """
+
+    def __init__(self, package_name: str | None = None) -> None:
+        self.package_name = package_name
+
+    def _is_not_free_threaded(self, url: str) -> bool:
+        """See https://peps.python.org/pep-0803/ ."""
+
+        wheel_info = parse_wheel_filename(url)
+
+        return not any(tag.endswith("t") for tag in wheel_info.abi_tags)
+
+    def __call__(self, urls: Iterable[str]) -> List[str]:
+        """Return URLs that are not free threaded.
+
+        :param urls: List of wheel URLs to filter.
+        :return: List of URLs that are not free threaded.
+        """
+        if not urls:
+            return []
+
+        urls = list(filter(self._is_not_free_threaded, urls))
+
+        if not urls and self.package_name:
+            msg = f"No suitable wheel found for {self.package_name} (free threaded wheels are not compatible with Blender), not downloading."
+            typer.echo(f"Warning: {msg}")
+
+        return urls
+
+
 class AbstractWheelsDownloader(ABC):
     """
     Abstract base class defining the interface for wheel downloaders.
@@ -390,13 +427,15 @@ def download_wheels(
     *,
     excluded_packages: Optional[List[str]] = None,
     supported_platforms: Optional[List[str]] = None,
+    include_free_threaded_wheels: bool = False,
 ) -> List[Path]:
     """Download the wheels from urls with pip download into wheels_directory.
 
     :param wheels_directory: The directory to download wheels into
     :param urls: A Dict with package name as key and a list of package urls as values.
-    :param excluded_packages: packages excluded from being downloaded
-    :param supported_platforms: only download wheels for theses platforms
+    :param excluded_packages: packages excluded from being downloaded.
+    :param supported_platforms: only download wheels for theses platforms.
+    :param include_free_threaded_wheels: whether to include free threaded wheels.
     :return: the list of the downloaded wheels path
     """
     wheels_directory.mkdir(parents=True, exist_ok=True)
@@ -417,6 +456,9 @@ def download_wheels(
 
         if supported_platforms:
             filters.add(PlatformIsNotExcluded(supported_platforms))
+
+        if not include_free_threaded_wheels:
+            filters.add(IsNotFreeThreaded(package_name))
 
         package_urls = reduce(lambda acc, filter_: filter_(acc), filters, package_urls)
 

--- a/tests/peeler/wheels/test_download.py
+++ b/tests/peeler/wheels/test_download.py
@@ -4,6 +4,7 @@ import pytest
 
 from peeler.wheels.download import (
     HasValidImplementation,
+    IsNotFreeThreaded,
     PackageIsNotExcluded,
     PlatformIsNotExcluded,
     _parse_implementation_and_python_version,
@@ -300,3 +301,106 @@ def test_PlatformIsNotExcluded_platform_mixed(
     supported_platform: List[str], urls: List[str], expected_urls: List[str]
 ) -> None:
     assert PlatformIsNotExcluded(supported_platform)(urls) == expected_urls
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://files.pythonhosted.org/packages/.../packagename-2.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.3.3-cp313-cp313t-win_amd64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename_core-2.41.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename_core-2.41.1-cp313-cp313t-win_amd64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-1.17.1-cp313-cp313t-win_amd64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.0.48-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.0.48-cp313-cp313t-win_amd64.whl",
+    ],
+)
+def test_IsNotFreeThreaded_filtered(url: str) -> None:
+    assert not IsNotFreeThreaded()([url])
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://files.pythonhosted.org/packages/.../packagename-2.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.3.3-cp313-cp313-win_amd64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.12.0-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/.../packagename_core-2.41.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename_core-2.41.1-cp313-cp313-win_amd64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-1.17.1-cp313-cp313-win_amd64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.0.48-cp313-cp313-win_amd64.whl",
+        "https://files.pythonhosted.org/packages/.../packagename-2.0.48-py3-none-any.whl",
+    ],
+)
+def test_IsNotFreeThreaded(url: str) -> None:
+    assert IsNotFreeThreaded()([url])
+
+
+@pytest.mark.parametrize(
+    ("urls", "expected_urls"),
+    [
+        [
+            [
+                "https://files.pythonhosted.org/packages/.../wheels/annotated_doc-0.0.4-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/annotated_types-0.7.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/anyio-4.11.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/fastapi-0.135.1-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/greenlet-3.2.4-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/idna-3.10-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/numpy-2.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/numpy-2.3.3-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/numpy-2.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/numpy-2.3.3-cp313-cp313t-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic-2.12.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic_core-2.41.1-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic_core-2.41.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic_core-2.41.1-cp313-cp313t-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/scipy-1.17.1-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/scipy-1.17.1-cp313-cp313t-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sniffio-1.3.1-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-cp313-cp313t-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/starlette-0.48.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/typing_extensions-4.15.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/typing_inspection-0.4.2-py3-none-any.whl",
+            ],
+            [
+                "https://files.pythonhosted.org/packages/.../wheels/annotated_doc-0.0.4-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/annotated_types-0.7.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/anyio-4.11.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/fastapi-0.135.1-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/greenlet-3.2.4-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/idna-3.10-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/numpy-2.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/numpy-2.3.3-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic-2.12.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/pydantic_core-2.41.1-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/scipy-1.17.1-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sniffio-1.3.1-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-cp313-cp313-win_amd64.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/sqlalchemy-2.0.48-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/starlette-0.48.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/typing_extensions-4.15.0-py3-none-any.whl",
+                "https://files.pythonhosted.org/packages/.../wheels/typing_inspection-0.4.2-py3-none-any.whl",
+            ],
+        ]
+    ],
+)
+def test_IsNotFreeThreaded_mixed(urls: List[str], expected_urls: List[str]) -> None:
+    assert IsNotFreeThreaded()(urls) == expected_urls


### PR DESCRIPTION
Close #129


* Avoid downloading wheels built for the free-threaded ABI (suffix `t`), as they are not compatible with Blender.
* Add a new option `--include-free-threaded-wheels` to explicitly allow downloading these wheels when needed.

Free-threaded Python builds are currently incompatible with Blender’s threading model and runtime constraints.
See: [https://docs.blender.org/api/current/info_gotchas_threading.html](https://docs.blender.org/api/current/info_gotchas_threading.html)

